### PR TITLE
Fix clang build error "ambiguous call to abs"

### DIFF
--- a/OpenNI2-FreenectDriver/src/VideoStream.hpp
+++ b/OpenNI2-FreenectDriver/src/VideoStream.hpp
@@ -52,7 +52,7 @@ namespace FreenectDriver
       if (timestamp < prev_timestamp)
       {
         uint32_t prev_int = static_cast<uint32_t>(prev_timestamp);
-        uint64_t temp_delta = std::abs(timestamp - prev_int);
+        uint64_t temp_delta = std::abs(static_cast<intmax_t>(timestamp - prev_int));
         prev_timestamp += temp_delta;
       } else {
         prev_timestamp = timestamp;


### PR DESCRIPTION
Fix the build on macOS with clang:

  OpenNI2-FreenectDriver/src/VideoStream.hpp:55:31: error: call to 'abs'
  is ambiguous
          uint64_t temp_delta = std::abs(timestamp - prev_int);
                              ^~~~~~~~

The same error does not occur with gcc 6.2.0.

Full build log:
https://gist.github.com/ilovezfs/3d48ebc7587cffc9830e0af78ef4b25b

```
In file included from /tmp/libfreenect-20160827-93325-9mef7q/libfreenect-0.5.4/OpenNI2-FreenectDriver/src/ColorStream.cpp:2:
In file included from /tmp/libfreenect-20160827-93325-9mef7q/libfreenect-0.5.4/OpenNI2-FreenectDriver/src/ColorStream.hpp:7:
/tmp/libfreenect-20160827-93325-9mef7q/libfreenect-0.5.4/OpenNI2-FreenectDriver/src/VideoStream.hpp:55:31: error: call to 'abs' is ambiguous
        uint64_t temp_delta = std::abs(timestamp - prev_int);
                              ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:664:1: note: candidate function
abs(float __lcpp_x) _NOEXCEPT {return fabsf(__lcpp_x);}
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:668:1: note: candidate function
abs(double __lcpp_x) _NOEXCEPT {return fabs(__lcpp_x);}
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:672:1: note: candidate function
abs(long double __lcpp_x) _NOEXCEPT {return fabsl(__lcpp_x);}
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/stdlib.h:129:6: note: candidate function
int      abs(int) __pure2;
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cstdlib:167:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cstdlib:169:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
                                           ^
1 error generated.
```
